### PR TITLE
Enhancements for DPC project

### DIFF
--- a/force-app/main/default/lwc/cookieConsent/cookieConsent.js
+++ b/force-app/main/default/lwc/cookieConsent/cookieConsent.js
@@ -28,6 +28,7 @@ export default class CookieConsent extends LightningElement {
   @api informationButtonLink = "https://www.salesforce.com";
   @api viewCookiesLabel = "View Cookies";
   @api viewCookiesLink = "https://www.salesforce.com";
+  @api openTargetWindow = "_blank";
   @api confirmButtonLabel = "Confirm Preferences";
   @api rejectButtonLabel = "Leave Site";
   @api cookieFooterRelative = false;
@@ -165,7 +166,7 @@ export default class CookieConsent extends LightningElement {
   }
 
   rejectCookies() {
-    window.history.back();
+    window.location.href="about:blank"; 
   }
 
   get shouldIShowCookieDialog() {
@@ -218,12 +219,12 @@ export default class CookieConsent extends LightningElement {
 
   informationButtonSelected() {
     let url = this.informationButtonLink;
-    window.open(url, "_blank");
+    window.open(url, this.openTargetWindow);
   }
 
   cookiesButtonSelected() {
     let url = this.viewCookiesLink;
-    window.open(url);
+    window.open(url, this.openTargetWindow);
   }
 
   get headingStyle() {

--- a/force-app/main/default/lwc/cookieConsent/cookieConsent.js-meta.xml
+++ b/force-app/main/default/lwc/cookieConsent/cookieConsent.js-meta.xml
@@ -23,6 +23,7 @@
             <property name="rejectButtonLabel" type="String" default="" label="Reject Button Label"/>
             <property name="viewCookiesLabel" type="String" default="" label="View Cookies Link Label"/>
             <property name="viewCookiesLink" type="String" default="" label="View Cookies Link"/>
+            <property name="openTargetWindow" type="String" default="_blank" label="Target window for links"/>
             <property name="cookieFooterRelative" type="Boolean" default="false" label="Used Relative Footer Positioning" description="If selected, the footer will be no longer be fixed to the window"/>
             <property name="cookieFooterPadding" type="String" default="small" datasource="xx-small, x-small, small, medium, large, none" label="Footer Padding"/>
             <property name="cookieFooterButtonAlignment" type="String" default="left" datasource="left, center, right" label="Footer Button Alignment"/>


### PR DESCRIPTION
Enhancements to support UK DPC project (2 Feb 23)

(1) Defect fix for "Reject" button
Current behaviour: The Reject button should prevent access to the application as Experience Cloud cookies are essential to operation. Currently the button click navigates to 'history.back'. This approach does not work if the user navigates to another portal page and then clicks Reject.
Updated behaviour: Force navigation to a blank page
[cookieConsent.js]

(2) Links to Privacy Policy and Cookies page open in a new window
Parameterised the target so that developer can pick a blank page (_blank) or to replace the current page (_self)
[cookieConsent.js, cookieConsent.js-meta.xml]